### PR TITLE
Changing the behavior the -iteration-limit option.

### DIFF
--- a/execution/exec_fuzzloop.ml
+++ b/execution/exec_fuzzloop.ml
@@ -85,7 +85,10 @@ let fuzz start_eip opt_fuzz_start_eip end_eips
 	     (fun a ->
 		if a = opt_fuzz_start_eip then
 		  (decr opt_fuzz_start_addr_count;
-		   !opt_fuzz_start_addr_count = 0)
+		   if !opt_fuzz_start_addr_count = 0 then 
+		     opt_iteration_limit_enforced := Some !opt_iteration_limit;
+		   !opt_fuzz_start_addr_count = 0
+		  )
 		else
 		  false))
       with

--- a/execution/exec_options.ml
+++ b/execution/exec_options.ml
@@ -58,6 +58,7 @@ let opt_branch_preference = Hashtbl.create 10
 let opt_branch_preference_unchecked = Hashtbl.create 10
 let opt_always_prefer = ref None
 let opt_iteration_limit = ref 1000000000000L
+let opt_iteration_limit_enforced = ref None
 let opt_insn_limit = ref Int64.minus_one
 let opt_watch_expr_str = ref None
 let opt_watch_expr = ref None

--- a/execution/exec_options.mli
+++ b/execution/exec_options.mli
@@ -36,6 +36,7 @@ val opt_branch_preference : (int64, int64) Hashtbl.t
 val opt_branch_preference_unchecked : (int64, int64) Hashtbl.t
 val opt_always_prefer : bool option ref
 val opt_iteration_limit : int64 ref
+val opt_iteration_limit_enforced : int64 option ref
 val opt_insn_limit : int64 ref
 val opt_watch_expr_str : string option ref
 val opt_watch_expr : Vine.exp option ref

--- a/execution/exec_runloop.ml
+++ b/execution/exec_runloop.ml
@@ -115,7 +115,9 @@ let rec runloop (fm : fragment_machine) eip asmir_gamma until =
 	  1L)
      in
        Hashtbl.replace loop_detect eip (Int64.succ old_count);
-       if old_count > !opt_iteration_limit then raise TooManyIterations);
+       (match !opt_iteration_limit_enforced with
+       | Some lim -> if old_count > lim then raise TooManyIterations
+       | _ -> ()););
     let (dl, sl) = decode_insns_cached fm asmir_gamma eip in
     let prog = (dl, sl) in
       let prog' = match call_replacements fm last_eip eip with

--- a/execution/fragment_machine.ml
+++ b/execution/fragment_machine.ml
@@ -2161,7 +2161,9 @@ struct
 	  | st :: rest -> find_label lab rest 
       in
 	loop_cnt <- Int64.succ loop_cnt;
-	if loop_cnt > !opt_iteration_limit then raise TooManyIterations;
+        (match !opt_iteration_limit_enforced with
+	| Some lim -> if loop_cnt > lim then raise TooManyIterations;
+	| _ -> ());
 	let (_, sl) = frag in
 	  match find_label lab sl with
 	    | None -> lab


### PR DESCRIPTION
This change enforces the iteration limit only after we wish to start
fuzzing instead of enforcing it from the beginning of execution.