### PR TITLE
Assert check that extra conditions are boolean (merge)

### DIFF
--- a/execution/sym_path_frag_machine.ml
+++ b/execution/sym_path_frag_machine.ml
@@ -236,6 +236,7 @@ struct
 	  | _ -> None 
 
     method private push_cond_to_qe cond =
+      assert(Vine_typecheck.infer_type_fast cond = V.REG_1);
       let (qdecls, cond_e, new_vars) =
 	form_man#one_cond_for_solving cond var_seen_hash
       in


### PR DESCRIPTION
Merging commit b3b2c475925bb8ff99795115c064e22336107f64 made in the fuzzball-adaptorsynth repository by Stephen McCamant
(mccamant@cs.umn.edu).
That commit message reads as follows:

Assert check that extra conditions are boolean

This kind of user error was previously making it all the way to the
solver, so this check should make it faster to catch.