### PR TITLE
Changing the ordering of declarations returned by one_cond_for_solving

### DIFF
--- a/execution/formula_manager.ml
+++ b/execution/formula_manager.ml
@@ -1171,9 +1171,9 @@ struct
 	     in
 	     let walked_qdecls3 =
 	       list_unique
-		 ((Vine_util.list_difference walked_qdecls2 mem_vars_as_in)
-		  @ mem_axioms_d
-		  @ mem_bytes_d)
+		 ( mem_bytes_d 
+		   @ mem_axioms_d
+		   @ (Vine_util.list_difference walked_qdecls2 mem_vars_as_in) )
 	     in
 	       (walked_qdecls3, cond_expr))
       in


### PR DESCRIPTION
Changing the ordering of declarations returned by one_cond_for_solving in formula_manager, especially for memory variables that are of size short, word, and long, so that in the solver input file, we get memory variable declarations before their use.