### PR TITLE
Fix a format string mismatch when converting array index constants to string

### DIFF
--- a/ocaml/smt_lib2.ml
+++ b/ocaml/smt_lib2.ml
@@ -35,7 +35,7 @@ let binary_str x len =
 
 let bvconst_str x len =
   if len mod 4 = 0 then
-    let fmt_str = "#x%0" ^ (string_of_int (len / 4)) ^ "x" in
+    let fmt_str = "#x%0" ^ (string_of_int (len / 4)) ^ "Lx" in
       sprintf (Scanf.format_from_string fmt_str "#x%0Lx") x
   else
     "#b" ^ (binary_str x len)


### PR DESCRIPTION
This fixes a "Scanf.Scan_failure("bad input: format type mismatch between \"#x%02x\" and \"#      x%0Lx\"")" error arising out of ocaml/smt_lib2.ml#bvconst_str that was causing the generated format string passed to Scanf.format_from_string to not match our hard-coded "#x%0Lx" format. This changes the code so that it generated a format string that matches our hard-coded version. This change is only relevant to use of FuzzBALL's "-tables-as-arrays" option that causes FuzzBALL to use theory of arrays support in the solver.