### PR TITLE
Add a binary search to find the negative minimum index of a lookup table

### DIFF
--- a/execution/sym_region_frag_machine.ml
+++ b/execution/sym_region_frag_machine.ml
@@ -1220,8 +1220,6 @@ struct
 
     val maxval_cache = Hashtbl.create 101
     val maxval_offset_cache = Hashtbl.create 101
-    val minval_cache = Hashtbl.create 101
-    val minval_offset_cache = Hashtbl.create 101
     val used_addr_cache = Hashtbl.create 101
     val dummy_vars_cache = Hashtbl.create 101
     val mutable dummy_counter = 0


### PR DESCRIPTION
This adds a binary search to find the negative minimum index before searching for the maximum index of a lookup table when loading a table.