### PR TITLE
Decision tree visualization

### DIFF
--- a/execution/binary_decision_tree.mli
+++ b/execution/binary_decision_tree.mli
@@ -46,4 +46,5 @@ class binary_decision_tree : object
 
   method measure_size : int
   method print_tree : out_channel -> unit
+  method print_dot : unit
 end

--- a/execution/decision_tree.ml
+++ b/execution/decision_tree.ml
@@ -43,4 +43,5 @@ class virtual decision_tree = object
 
   method virtual measure_size : int
   method virtual print_tree : out_channel -> unit
+  method virtual print_dot : unit
 end

--- a/execution/decision_tree.mli
+++ b/execution/decision_tree.mli
@@ -41,4 +41,5 @@ class virtual decision_tree : object
 
   method virtual measure_size : int
   method virtual print_tree : out_channel -> unit
+  method virtual print_dot : unit
 end

--- a/execution/exec_options.ml
+++ b/execution/exec_options.ml
@@ -80,6 +80,7 @@ let opt_solver_slow_time = ref 1.0
 let opt_save_solver_files = ref false
 let opt_solver_path = ref "stp"
 let opt_follow_path = ref ""
+let opt_save_decision_tree_dot = ref ""
 let opt_branch_preference = Hashtbl.create 10
 let opt_branch_preference_unchecked = Hashtbl.create 10
 let opt_always_prefer = ref None

--- a/execution/exec_options.mli
+++ b/execution/exec_options.mli
@@ -53,6 +53,7 @@ val opt_solver_timeout : int option ref
 val opt_timeout_as_unsat : bool ref
 val opt_solver_slow_time : float ref
 val opt_save_solver_files : bool ref
+val opt_save_decision_tree_dot : string ref
 val opt_solver_path : string ref
 val opt_follow_path : string ref
 val opt_branch_preference : (int64, int64) Hashtbl.t

--- a/execution/exec_options_table.ml
+++ b/execution/exec_options_table.ml
@@ -48,7 +48,6 @@ let  getParameterTable () =
     add_parameter "-solver-check-against" (String OS.opt_solver_check_against);
     add_parameter "-solver-path" (String EO.opt_solver_path);
     add_parameter "-smtlib-solver-type" (StringOpt OS.opt_smtlib_solver_type_string);
-    add_parameter "-save-solver-files" (Bool EO.opt_save_solver_files);
     add_parameter "-solver-slow-time" (Float EO.opt_solver_slow_time);
     add_parameter "-solver-timeout" (IntOpt EO.opt_solver_timeout);
     add_parameter "-trace-assigns" (Bool EO.opt_trace_assigns);
@@ -174,6 +173,7 @@ let  getParameterTable () =
     add_parameter "-coverage-stats" (Bool EO.opt_coverage_stats);
     add_parameter "-offset-strategy" (String EO.opt_offset_strategy_string);
     add_parameter "-follow-path" (String EO.opt_follow_path);
+    add_parameter "-save-decision-tree-dot" (String EO.opt_save_decision_tree_dot);
     add_parameter "-branch-preference" (Int64Hashtbl EO.opt_branch_preference);
     add_parameter "-random-seed" (Int EO.opt_random_seed);
     add_parameter "-save-decision-tree-interval" (FloatOpt EO.opt_save_decision_tree_interval);

--- a/execution/exec_options_table.ml
+++ b/execution/exec_options_table.ml
@@ -174,6 +174,7 @@ let  getParameterTable () =
     add_parameter "-coverage-stats" (Bool EO.opt_coverage_stats);
     add_parameter "-offset-strategy" (String EO.opt_offset_strategy_string);
     add_parameter "-follow-path" (String EO.opt_follow_path);
+    add_parameter "-branch-preference" (Int64Hashtbl EO.opt_branch_preference);
     add_parameter "-random-seed" (Int EO.opt_random_seed);
     add_parameter "-save-decision-tree-interval" (FloatOpt EO.opt_save_decision_tree_interval);
     add_parameter "-decision-tree-use-file" (Bool EO.opt_decision_tree_use_file);

--- a/execution/exec_options_table.ml
+++ b/execution/exec_options_table.ml
@@ -48,6 +48,7 @@ let  getParameterTable () =
     add_parameter "-solver-check-against" (String OS.opt_solver_check_against);
     add_parameter "-solver-path" (String EO.opt_solver_path);
     add_parameter "-smtlib-solver-type" (StringOpt OS.opt_smtlib_solver_type_string);
+    add_parameter "-save-solver-files" (Bool EO.opt_save_solver_files);
     add_parameter "-solver-slow-time" (Float EO.opt_solver_slow_time);
     add_parameter "-solver-timeout" (IntOpt EO.opt_solver_timeout);
     add_parameter "-trace-assigns" (Bool EO.opt_trace_assigns);
@@ -173,8 +174,6 @@ let  getParameterTable () =
     add_parameter "-coverage-stats" (Bool EO.opt_coverage_stats);
     add_parameter "-offset-strategy" (String EO.opt_offset_strategy_string);
     add_parameter "-follow-path" (String EO.opt_follow_path);
-    add_parameter "-save-decision-tree-dot" (String EO.opt_save_decision_tree_dot);
-    add_parameter "-branch-preference" (Int64Hashtbl EO.opt_branch_preference);
     add_parameter "-random-seed" (Int EO.opt_random_seed);
     add_parameter "-save-decision-tree-interval" (FloatOpt EO.opt_save_decision_tree_interval);
     add_parameter "-decision-tree-use-file" (Bool EO.opt_decision_tree_use_file);

--- a/execution/exec_set_options.ml
+++ b/execution/exec_set_options.ml
@@ -436,6 +436,9 @@ let explore_cmdline_opts =
      "SIZE Introduce temporaries for exprs of size or larger");
     ("-trace-simplify", Arg.Set(opt_trace_simplify),
      " Print expression simplifications");
+    ("-save-decision-tree-dot", 
+     Arg.Set_string(opt_save_decision_tree_dot), 
+     "filename Save dot format decision tree to file");
   ]
 
 

--- a/execution/linear_decision_tree.ml
+++ b/execution/linear_decision_tree.ml
@@ -95,4 +95,5 @@ class linear_decision_tree = object(self)
   method measure_size = depth
 
   method print_tree chan = ()
+  method print_dot = ()
 end

--- a/execution/linear_decision_tree.mli
+++ b/execution/linear_decision_tree.mli
@@ -43,4 +43,5 @@ class linear_decision_tree : object
 
   method measure_size : int
   method print_tree : out_channel -> unit
+  method print_dot : unit
 end

--- a/execution/sym_path_frag_machine.ml
+++ b/execution/sym_path_frag_machine.ml
@@ -960,6 +960,7 @@ struct
 	
     method finish_path =
       dt#set_heur 1;
+      dt#print_dot;
       dt#mark_all_seen;
       infl_man#finish_path;
       if !opt_trace_binary_paths then


### PR DESCRIPTION
Save decision tree in .dot format to a file.
To read the tree, convert the dot file to pdf using dot's -Tpdf option