### PR TITLE
Ignore .annot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.cmx
 *.cmo
 *.cma
+*.annot
 /Makefile
 /Makefile.in
 aclocal.m4


### PR DESCRIPTION
OCaml compiler general .annot files when ANNOTATE is set to true.
Tell git to ignore those files.