### PR TITLE
Fix fd leakage for smtlib

### DIFF
--- a/execution/smtlib_external_engine.ml
+++ b/execution/smtlib_external_engine.ml
@@ -237,5 +237,8 @@ class smtlib_external_engine solver fname = object(self)
       self#reset_solver_chans;
       first_query <- true;
       visitor <- None;
+      match log_chan with
+        | Some chan -> close_out chan
+        | None ->();
 
 end


### PR DESCRIPTION
Fix the bug that output files are not closed when using smtlib and turn on -save-solver-files.