### PR TITLE
Fix -extra-conditions variable declaration

### DIFF
--- a/execution/formula_manager.ml
+++ b/execution/formula_manager.ml
@@ -177,6 +177,11 @@ struct
 
     val region_vars = Hashtbl.create 30
 
+    method declare_symbolic_region str =
+      if not (Hashtbl.mem region_vars str) then
+        Hashtbl.replace region_vars str
+          (V.newvar str (V.TMem(V.REG_32, V.Little)))
+
     method private fresh_symbolic_mem ty str addr =
       let v = try Hashtbl.find region_vars str with
 	  Not_found ->

--- a/execution/formula_manager.mli
+++ b/execution/formula_manager.mli
@@ -24,6 +24,8 @@ sig
 
     method known_region_base : Vine.var -> bool
 
+    method declare_symbolic_region : string -> unit
+
     method fresh_symbolic_mem_1  : string -> int64 -> D.t
     method fresh_symbolic_mem_8  : string -> int64 -> D.t
     method fresh_symbolic_mem_16 : string -> int64 -> D.t

--- a/execution/fragment_machine.ml
+++ b/execution/fragment_machine.ml
@@ -399,6 +399,7 @@ class virtual fragment_machine = object
 
   method virtual make_symbolic_region : int64 -> int -> string -> int -> unit
   method virtual make_fresh_symbolic_region : int64 -> int -> unit
+  method virtual declare_symbolic_region : string -> unit
 
   method virtual store_symbolic_cstr : int64 -> int -> bool -> bool -> unit
   method virtual store_concolic_cstr : int64 -> string -> bool -> unit
@@ -2491,6 +2492,9 @@ struct
       let varname = "input" ^ (string_of_int symbolic_string_id) in
         symbolic_string_id <- symbolic_string_id + 1;
         self#make_symbolic_region base len varname 0
+
+    method declare_symbolic_region str =
+      form_man#declare_symbolic_region str
 
     method store_symbolic_cstr base len fulllen terminate =
       let varname = "input" ^ (string_of_int symbolic_string_id) ^ "_" in

--- a/execution/fragment_machine.mli
+++ b/execution/fragment_machine.mli
@@ -182,6 +182,7 @@ class virtual fragment_machine : object
 
   method virtual make_symbolic_region : int64 -> int -> string -> int -> unit
   method virtual make_fresh_symbolic_region : int64 -> int -> unit
+  method virtual declare_symbolic_region : string -> unit
 
   method virtual store_symbolic_cstr : int64 -> int -> bool -> bool -> unit
   method virtual store_concolic_cstr : int64 -> string -> bool -> unit
@@ -435,6 +436,7 @@ sig
 
     method make_symbolic_region : int64 -> int -> string -> int -> unit
     method make_fresh_symbolic_region : int64 -> int -> unit
+    method declare_symbolic_region : string -> unit
 
     method store_symbolic_cstr : int64 -> int -> bool -> bool -> unit
     method store_concolic_cstr : int64 -> string -> bool -> unit

--- a/execution/options_linux.ml
+++ b/execution/options_linux.ml
@@ -136,6 +136,10 @@ let apply_linux_cmdline_opts (fm : Fragment_machine.fragment_machine) =
 	lsh#add_symbolic_fd 0 false;
       if !opt_concolic_stdin then
 	lsh#add_symbolic_fd 0 true;
+      if (!opt_symbolic_files <> []) || (!opt_concolic_files <> []) || !opt_concolic_stdin
+         || !opt_symbolic_stdin_concrete_size then
+        (fm#declare_symbolic_region "file";
+         fm#declare_symbolic_region "stdin");
       Linux_syscalls.linux_set_up_arm_kuser_page fm;
       fm#add_special_handler (lsh :> Fragment_machine.special_handler)
   else if !opt_noop_syscalls then

--- a/execution/sym_path_frag_machine.mli
+++ b/execution/sym_path_frag_machine.mli
@@ -199,6 +199,7 @@ sig
     method store_str : int64 -> int64 -> string -> unit
     method make_symbolic_region : int64 -> int -> string -> int -> unit
     method make_fresh_symbolic_region : int64 -> int -> unit
+    method declare_symbolic_region : string -> unit
     method store_symbolic_cstr : int64 -> int -> bool -> bool -> unit
     method store_concolic_cstr : int64 -> string -> bool -> unit
     method store_concolic_name_str :

--- a/execution/sym_region_frag_machine.mli
+++ b/execution/sym_region_frag_machine.mli
@@ -204,6 +204,7 @@ sig
     method store_str : int64 -> int64 -> string -> unit
     method make_symbolic_region : int64 -> int -> string -> int -> unit
     method make_fresh_symbolic_region : int64 -> int -> unit
+    method declare_symbolic_region : string -> unit
     method store_symbolic_cstr : int64 -> int -> bool -> bool -> unit
     method store_concolic_cstr : int64 -> string -> bool -> unit
     method store_concolic_name_str :


### PR DESCRIPTION
When file/stdin is set to symbolic, FuzzBALL does not create associated symbolic variables until first read. As a result, if extra conditions involve those symbolic vars, they are not yet declared when extra conditions are parsed, which will cause an error.

To fix this error, declare symbolic vars for file and stdin whenever file or stdin is set to symbolic

Merged from hb-branch cb761b937d7b5e5d4c814535b48cf23b9450be89 and f25b84dbeb9723cacb6e441278517036343808de